### PR TITLE
Fix: Add google-auth to assistant cog requirements

### DIFF
--- a/assistant/info.json
+++ b/assistant/info.json
@@ -21,7 +21,8 @@
     "sentry_sdk",
     "tenacity",
     "tiktoken",
-    "ujson"
+    "ujson",
+    "google-auth"
   ],
   "short": "Advanced AI assistant (or chat) cog for your server with OpenAI's ChatGPT language models",
   "tags": [


### PR DESCRIPTION
The assistant cog was failing to load due to a missing `google.auth` module. This change adds `google-auth` to the `requirements` list in the cog's `info.json` file.

I've confirmed that `google-auth` installs correctly. However, I was prevented from performing a full cog loading test by issues setting up the `redbot-cli` environment. Despite this, the direct cause of the reported `ModuleNotFoundError` should now be resolved.