### PR TITLE
feat: Enable AI Studio GEMINI_API_KEY for Gemini models

### DIFF
--- a/assistant/common/models.py
+++ b/assistant/common/models.py
@@ -346,6 +346,7 @@ class DB(AssistantBaseModel):
     brave_api_key: t.Optional[str] = None
     endpoint_override: t.Optional[str] = None
     google_project_id: t.Optional[str] = None
+    gemini_api_key: t.Optional[str] = None
 
     def get_conf(self, guild: t.Union[discord.Guild, int]) -> GuildSettings:
         gid = guild if isinstance(guild, int) else guild.id


### PR DESCRIPTION
This commit introduces the ability to use API keys from Google AI Studio (generativelanguage.googleapis.com) for authenticating requests to Gemini models.

Key changes:
- Added `gemini_api_key` to global settings (`DB` model).
- Modified `request_response` and `request_embedding` in `api.py` to check for `gemini_api_key`. If present, it's used with the Generative Language API endpoint. Otherwise, it falls back to the existing Google Cloud ADC (Vertex AI) authentication.
- Updated `request_gemini_chat_completion_raw` and `request_gemini_embedding_raw` to handle both authentication methods by:
    - Using the correct endpoint URL.
    - Sending the API key as a query parameter (`?key=`) for AI Studio or using a Bearer token for ADC/Vertex.
    - Adjusting payload and response parsing for embeddings when using AI Studio (e.g., `embedContent` API differences).
- Token counting and helper functions were reviewed and required no changes as they are auth-agnostic.

This allows you to leverage Gemini models via the simpler API key authentication provided by AI Studio, in addition to the existing Vertex AI integration. Manual testing steps and documentation updates have been prepared.