### PR TITLE
Fix: Correct indentation error in Gemini embedding request

### DIFF
--- a/assistant/common/api.py
+++ b/assistant/common/api.py
@@ -416,10 +416,10 @@ class API(MixinMeta):
                             _("Gemini Embedding API request failed with status {status}: {error}").format(status=resp.status, error=err_text)
                         )
 
-            response_json = await resp.json()
+                response_json = await resp.json()
 
-            # Validation is now handled by the caller (request_embedding) due to different response structures
-            return response_json
+                # Validation is now handled by the caller (request_embedding) due to different response structures
+                return response_json
 
     async def request_openai_embedding_raw(self, text: str, api_key: str, model: str, base_url: Optional[str] = None ) -> CreateEmbeddingResponse:
         return await request_embedding_raw( 


### PR DESCRIPTION
The response handling for Gemini embedding requests was incorrectly unindented, leading to an IndentationError because the `resp` object was out of scope.

This commit corrects the indentation for the following lines in `assistant/common/api.py` to be within the `async with` block:
- `response_json = await resp.json()`
- The comment regarding validation handling
- `return response_json`

This ensures that the JSON response is processed correctly within the context of the active response object.