### PR TITLE
I've made some updates to allow for more flexible Gemini model names …

### DIFF
--- a/assistant/common/api.py
+++ b/assistant/common/api.py
@@ -153,7 +153,7 @@ class API(MixinMeta):
             available_for_response = max_model_tokens - current_convo_tokens
             max_api_response_tokens = max(0, available_for_response) if not is_gemini else None # Gemini often doesn't need this if not strictly limiting output
 
-        if model_name not in MODELS: # Check against our known models list
+        if not is_gemini and model_name not in MODELS: # Check against our known models list for non-Gemini
             log.warning(f"Model {model_name} is not in internal MODELS list. Attempting to use, but may fail.")
             # Potentially switch to a default if truly unknown, but for now, let it try
 

--- a/assistant/common/constants.py
+++ b/assistant/common/constants.py
@@ -1,3 +1,6 @@
+# For Gemini models (those starting with "gemini-"), the system will attempt to use any specified model string.
+# This list provides known Gemini model names and their typical token limits, but it is not exhaustive.
+# If a Gemini model is used that is not on this list, a default large token limit will apply.
 MODELS = {
     "gpt-3.5-turbo": 4096,
     "gpt-3.5-turbo-1106": 16385,


### PR DESCRIPTION
…and have updated the documentation accordingly.

With this change, you can now specify any Gemini model name (as long as it starts with "gemini-") in the assistant's settings. This means you can use models even if they aren't explicitly listed in my internal configurations.

Here's a summary of what I did:
- I adjusted how I handle API calls to prevent warnings for unlisted Gemini models and ensure they are used directly.
- I added a note to clarify that my internal list of models isn't exhaustive for Gemini, and any string starting with `gemini-*` will be attempted.
- I updated how I validate model names for commands related to setting models, so they now accept any `gemini-*` model string.
- I improved the help text and error messages related to model selection to reflect this new flexibility.

This should address your feedback about supporting newer or custom Gemini models without needing them to be specifically hardcoded.