### PR TITLE
Fix: Add API key check for non-Gemini embedding models

### DIFF
--- a/assistant/common/api.py
+++ b/assistant/common/api.py
@@ -351,6 +351,13 @@ class API(MixinMeta):
             )
             return embedding_values
         else: # OpenAI or compatible
+            if not conf.api_key:
+                raise commands.UserFeedbackCheckFailure(
+                    _(
+                        "API key is missing. The selected embedding model '{model_name}' requires an OpenAI or compatible API key. "
+                        "Please set one or choose a Gemini embedding model."
+                    ).format(model_name=model_name)
+                )
             api_key_to_use = conf.api_key # Standard OpenAI key
             response: CreateEmbeddingResponse = await self.request_openai_embedding_raw(
                 text=text,


### PR DESCRIPTION
Previously, if a non-Gemini (e.g., OpenAI) embedding model was selected and no corresponding API key was configured, the system would attempt to initialize the OpenAI client with a missing key, resulting in an `openai.OpenAIError`.

This change modifies the `request_embedding` method in `assistant/common/api.py`. It now explicitly checks if an API key (`conf.api_key`) is present when the selected embedding model is not a Gemini model. If the key is missing, it raises a `commands.UserFeedbackCheckFailure` with a clear message guiding you to set the required key or switch to a Gemini model.

This prevents the `OpenAIError` and provides a more user-friendly error message, improving your experience when configurations are incomplete for the chosen embedding provider. The existing logic for handling Gemini embedding providers remains unchanged.