### PR TITLE
Add comprehensive Gemini model configuration

### DIFF
--- a/assistant/common/models.py
+++ b/assistant/common/models.py
@@ -95,6 +95,10 @@ class GuildSettings(AssistantBaseModel):
     model: str = "gpt-4o-mini"
     embed_model: str = "text-embedding-3-small"  # Or text-embedding-3-large, text-embedding-ada-002
     collab_convos: bool = False
+    gemini_safety_settings: t.Dict[str, str] = Field(default_factory=dict)
+    gemini_generation_config: t.Dict[str, t.Any] = Field(default_factory=dict)
+    gemini_enable_google_search: bool = False
+    gemini_enable_thinking: bool = False
     reasoning_effort: str = "low"  # low, medium, high
 
     channel_context_enabled: bool = False


### PR DESCRIPTION
This commit introduces the ability to adjust various Gemini-specific settings at the guild level.

New features include:
- Configuration of Gemini safety settings (harm category thresholds).
- Adjustment of Gemini generation parameters (topP, topK, candidateCount, etc.).
- Ability to enable/disable Google Search grounding as a tool for Gemini.
- A feature to toggle a "thinking" prompt to encourage more verbose reasoning from the model.

These settings are managed via a new `assistant geminisettings` command group and are displayed in the `assistant view` output. The API interaction logic has been updated to incorporate these settings into calls made to Gemini models.